### PR TITLE
Implemented suggestions from feedback before CR2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ version = "1.0.0-DEV"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 LinearAlgebra = "1.11.0"
-LoopVectorization = "0.12.173"
 StatsBase = "0.34.9"
 julia = "1.11"

--- a/docs/src/devs.md
+++ b/docs/src/devs.md
@@ -4,8 +4,26 @@ You want to understand how this package works or modify the code you are running
 
 ## Tokenizer
 
-Explain `Tokenizer` and surrounding functionality.
+```@docs
+Tokenizer
+Llama2.TokenIndex
+Llama2.compare_tokens
+Llama2.str_lookup
+Llama2.encode
+```
 
 ## Transformer
 
-Explain `Transformer` and surrounding functionality.
+```@docs
+Llama2.Transformer
+Llama2.Config
+Llama2.TransformerWeights
+Llama2.RunState
+```
+
+## forward!
+
+```@docs
+Llama2.rmsnorm
+Llama2.softmax!
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,37 +14,15 @@ LLama2 is a family of pre-trained LLMs by Meta AI. More information can be found
 
 ## Getting started
 
-Clone the repository to a desired location:
-
-```
-cd /PATH/TO/DESIRED/LOCATION/
-git clone git@github.com:ConstantConstantin/Llama2.git
-```
-
 Start julia, activate a desired environment and add the package; it can then be loaded in your session:
 
 ```julia
 (@v1.11) pkg> activate .
-  Activating new project at `PATH/TO/MY/ENVIRONMENT/myLlama2`
 
-(myLlama2) pkg> add /PATH/TO/DESIRED/LOCATION/Llama2/
-     Cloning git-repo `/PATH/TO/DESIRED/LOCATION/Llama2`
-    Updating git-repo `/PATH/TO/DESIRED/LOCATION/Llama2`
-    Updating registry at `~/.julia/registries/General.toml`
-   Resolving package versions...
-    Updating `PATH/TO/MY/ENVIRONMENT/Project.toml`
-  [0e620e9f] + Llama2 v1.0.0-DEV `/PATH/TO/DESIRED/LOCATION/Llama2#aj/docs`
-    Updating `PATH/TO/MY/ENVIRONMENT/Manifest.toml`
-  [0e620e9f] + Llama2 v1.0.0-DEV `/PATH/TO/DESIRED/LOCATION/Llama2#aj/docs`
-Precompiling project...
-  1 dependency successfully precompiled in 1 seconds
+(myLlama2) pkg> add https://github.com/ConstantConstantin/Llama2.jl
 
 julia> using Llama2
 ```
 
 ```@index
-```
-
-```@autodocs
-Modules = [Llama2]
 ```

--- a/docs/src/inference.md
+++ b/docs/src/inference.md
@@ -9,4 +9,9 @@ wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
 ```
 
 ## Inferencing
-We need more working code for this.
+
+You can either generate a single text, optionally giving an input prompt, or have an interactive chat (TODO).
+
+```@docs
+talktollm
+```

--- a/src/Llama2.jl
+++ b/src/Llama2.jl
@@ -1,8 +1,9 @@
 module Llama2
 
 using StatsBase: wsample
+using LinearAlgebra: dot
 
-export Tokenizer, TokenIndex, compare_tokens, str_lookup, encode, talktollm
+export Tokenizer, talktollm
 
 include("structs.jl")
 include("tokenizer.jl")
@@ -17,8 +18,6 @@ model from `modelpath` and the corresponding tokenizer from `vocabpath`. It take
 `prompt` string to start the text generation and generates up to `max_tokens` tokens.
 
 ```julia
-julia> using Llama2;
-
 julia> talktollm("/PATH/TO/MODEL.bin"
                 ,"/PATH/TO/VOCAB.bin"
                 ,"hey whats up?", 100);

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -1,7 +1,3 @@
-using LinearAlgebra: dot
-
-using LoopVectorization: @turbo
-
 """
     rmsnorm(x, w)
 
@@ -19,9 +15,6 @@ julia> o = Llama2.rmsnorm(x, w)
  0.9258191
  1.3887286
 ```
-
-# Developer Notes
-Dimensions x and w not quite sure yet.
 """
 function rmsnorm(x::AbstractVector{Float32}, w::AbstractVector{Float32})
 
@@ -41,18 +34,17 @@ end
 """
 softmax!(x)
 Updates the Output of an Layer 'x' with the softmax of the input.
-Using @turbo for performance optimization.
 
 # Examples
 ```jldoctest
 julia> x = [-1.0f0,0,1];
 
-julia> Llama2.softmax!(x)
+julia> Llama2.softmax!(x);
 
 julia> x
 3-element Vector{Float32}:
  0.09003057
- 0.24472846
+ 0.24472848
  0.66524094
 ```
 """
@@ -62,13 +54,13 @@ function softmax!(x::AbstractVector{Float32})
 
     max_x = maximum(x)
 
-    @turbo for i in eachindex(x)
+    for i in eachindex(x)
         x[i] = exp(x[i] - max_x)
     end
 
     x ./= sum(x)
 
-    return nothing
+    return x
 end
 
 function forward!(transformer::Transformer, token::Int32, pos::Int32)

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -1,28 +1,24 @@
 """
     TokenIndex(str::String, id::Integer)
 
-Create a `TokenIndex` from a string and an integer identifier.
+Create a `TokenIndex` from `str` and the identifier `id`.
 
 The byte sequence is converted to `String` and the ID is
 converted to `Int16`.  
 Throw a `DomainError` if `id ≤ 0`.
 
-
 # Examples
 ```jldoctest
-julia> using Llama2;
+julia> Llama2.TokenIndex("Julia", 1)
+Llama2.TokenIndex("Julia", 1)
 
-julia> TokenIndex("Julia", 1)
-TokenIndex("Julia", 1)
-
-julia> TokenIndex("Julia", -1)
+julia> Llama2.TokenIndex("Julia", -1)
 ERROR: DomainError with Token index must be > 0.
 [...]
 ```
 
 # Developer Notes
 This is an internal struct.
-
 """
 struct TokenIndex
 
@@ -39,20 +35,17 @@ end
 """
     compare_tokens(first_token::TokenIndex, second_token::TokenIndex) -> Bool
 
-Compare two `TokenIndex` objects by their string values.
-It returns `true` if the first token's string is **lexicographically** less than the second's, and `false` otherwise.
+Compare two `first_token` and `scond_token` by their string values.
+It returns `true` if `first_token`'s string is **lexicographically** less than the second's, and `false` otherwise.
 
 # Examples
 ```jldoctest
-julia> using Llama2;
-
-julia> compare_tokens(TokenIndex("A", 1), TokenIndex("B", 2))
+julia> Llama2.compare_tokens(Llama2.TokenIndex("A", 1), Llama2.TokenIndex("B", 2))
 true
 
-julia> compare_tokens(TokenIndex("B", 1), TokenIndex("A", 2))
+julia> Llama2.compare_tokens(Llama2.TokenIndex("B", 1), Llama2.TokenIndex("A", 2))
 false
 ```
-
 """
 function compare_tokens(first_token::TokenIndex, second_token::TokenIndex)::Bool
     return isless(first_token.str, second_token.str)
@@ -131,21 +124,18 @@ end
 """
     str_lookup(str::String, sorted_vocab::Vector{TokenIndex}) -> Int16
 
-Search for a given string `str` within a sorted vocabulary `sorted_vocab` of `TokenIndex` objects.
-If the string is found, it returns the corresponding token ID;
+Search for `str` within a sorted vocabulary `sorted_vocab`.
+If a match is found, it returns the corresponding token ID;
 **otherwise, it returns `-1`.** It uses a binary search for efficient lookup.
 
 # Examples
 ```jldoctest
-julia> using Llama2;
-
-julia> str_lookup("aa", [TokenIndex("aa", 1), TokenIndex("bb", 2)])
+julia> Llama2.str_lookup("aa", [Llama2.TokenIndex("aa", 1), Llama2.TokenIndex("bb", 2)])
 1
 
-julia> str_lookup("ba", [TokenIndex("aa", 1), TokenIndex("bb", 2)])
+julia> Llama2.str_lookup("ba", [Llama2.TokenIndex("aa", 1), Llama2.TokenIndex("bb", 2)])
 -1
 ```
-
 """
 function str_lookup(str::String, sorted_vocab::Vector{TokenIndex})::Int16
 
@@ -159,13 +149,12 @@ function str_lookup(str::String, sorted_vocab::Vector{TokenIndex})::Int16
 end
 
 """
-    encode
+    encode(tokenizer::Tokenizer, text::String)
 
-Converts a string `text` into a sequence of token IDs using a `Tokenizer`.
+Converts `text` into a sequence of token IDs using `tokenizer`.
 First ensure the tokenizer's vocabulary is sorted, then encode each character into its corresponding ID.
 After that, iteratively merge token pairs with the highest scores to form longer tokens until no more merges are possible.
 Return the final token ID sequence.
-
 """
 function encode(tokenizer::Tokenizer, text::String)
 
@@ -186,7 +175,7 @@ function encode(tokenizer::Tokenizer, text::String)
     end
 
     while true
-        best_score = -1e10
+        best_score = -1f10
         best_id = -1
         best_idx = -1
 

--- a/test/forward.jl
+++ b/test/forward.jl
@@ -1,0 +1,42 @@
+@testset "forward" begin
+
+    @testset "helpers" begin
+
+        empty_vector = Vector{Float32}(undef, 0)
+        x4 = [1.0f0, 2, 3, 4]
+        y4 = [1.0f0, 1, 1, 1]
+        x5 = [1.0f0, 5, 4, 3, 2]
+        y5 = [1.0f0, 1, 1, 1, 1]
+    
+        @testset "rmsnorm" begin
+
+            @test Llama2.rmsnorm(x4, y4) isa AbstractVector{Float32}
+        
+            @test Llama2.rmsnorm(x4, y4) == Float32[0.36514813, 0.73029625, 1.0954444, 1.4605925]
+            @test Llama2.rmsnorm(x4, x4) == Float32[0.36514813, 1.4605925, 3.2863333, 5.84237]
+            @test Llama2.rmsnorm(y4, y4) == Float32[0.999995, 0.999995, 0.999995, 0.999995]
+            @test Llama2.rmsnorm(x5, y5) == Float32[0.3015112, 1.507556, 1.2060448, 0.9045336, 0.6030224]
+            @test Llama2.rmsnorm(x5, x5) == Float32[0.3015112, 7.53778, 4.824179, 2.7136009, 1.2060448]
+            @test Llama2.rmsnorm(y5, y5) == Float32[0.999995, 0.999995, 0.999995, 0.999995, 0.999995]
+
+            @test_throws DimensionMismatch Llama2.rmsnorm(x4, y5)
+            @test_throws ArgumentError Llama2.rmsnorm(empty_vector, empty_vector)
+
+        end
+
+        @testset "softmax!" begin
+
+            @test Llama2.softmax!(x4) isa AbstractVector{Float32}
+            @test x4 == Float32[0.032058604, 0.08714432, 0.23688284, 0.6439143]
+            Llama2.softmax!.((y4, x5, y5))
+            @test y4 == Float32[0.25, 0.25, 0.25, 0.25]
+            @test x5 == Float32[0.01165623, 0.63640857, 0.23412165, 0.08612854, 0.031684916]
+            @test y5 == Float32[0.2, 0.2, 0.2, 0.2, 0.2]
+
+            @test_throws ArgumentError Llama2.softmax!(empty_vector)
+
+        end
+
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using Llama2
 using Test
 
 @testset "Llama2.jl" begin
-    # Write your tests here.
+    include("forward.jl")
 end


### PR DESCRIPTION
This PR includes several small changes:
* Improved docs (extended, removed duplications, correct installation guide, remove `using Llama2` call from several examples in docstrings, ...)
* remove exports for internal structs/functions
* remove LoopVectorization as dependency ("overkill")
* add more tests (and doctests should hopefully run now, too)
* replace a `Float64` with a `Float32`; for our case we will stick to `Float32` usage - for the aim of this project we don't need generality